### PR TITLE
Add API key auth & update Swagger config

### DIFF
--- a/Src/WeatherForecast.Api/ApiKeyAuthenticationSchemeHandler.cs
+++ b/Src/WeatherForecast.Api/ApiKeyAuthenticationSchemeHandler.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+
+namespace WeatherForecast.Api
+{
+public class ApiKeyAuthenticationSchemeHandler : AuthenticationHandler<ApiKeyAuthenticationSchemeOptions>
+{
+    public ApiKeyAuthenticationSchemeHandler(IOptionsMonitor<ApiKeyAuthenticationSchemeOptions> options,
+        ILoggerFactory logger, UrlEncoder encoder) : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("X-Api-Key", out var apiKeyHeaderValues))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Missing API Key"));
+        }
+
+        var apiKey = apiKeyHeaderValues.FirstOrDefault();
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Missing API Key"));
+        }
+
+        if (apiKey != Options.ApiKey)
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API Key"));
+        }
+
+        var claims = new[] { new Claim(ClaimTypes.Name, "API User") };
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}
+}

--- a/Src/WeatherForecast.Api/ApiKeyAuthenticationSchemeOptions.cs
+++ b/Src/WeatherForecast.Api/ApiKeyAuthenticationSchemeOptions.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Authentication;
+
+namespace WeatherForecast.Api
+{
+    public class ApiKeyAuthenticationSchemeOptions : AuthenticationSchemeOptions
+    {
+        public string? ApiKey { get; set; }
+    }
+}

--- a/Src/WeatherForecast.Api/Controllers/WeatherForecastController.cs
+++ b/Src/WeatherForecast.Api/Controllers/WeatherForecastController.cs
@@ -1,5 +1,6 @@
 using Asp.Versioning;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace WeatherForecast.Api.Controllers;
@@ -9,6 +10,7 @@ namespace WeatherForecast.Api.Controllers;
 [ApiVersion(1.0)]
 [ApiVersion(2.0)]
 [ApiVersion(3.0)]
+[Authorize]
 public class WeatherForecastController : ControllerBase
 {
     private static readonly string[] Summaries = new[]

--- a/Src/WeatherForecast.Api/Program.cs
+++ b/Src/WeatherForecast.Api/Program.cs
@@ -10,6 +10,10 @@ using WeatherForecast.Api;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Services.AddAuthentication("ApiKey")
+    .AddScheme<ApiKeyAuthenticationSchemeOptions, ApiKeyAuthenticationSchemeHandler>("ApiKey",
+    options => { options.ApiKey = builder.Configuration["ApiKey"]; });
+
 builder.Services.AddControllers();
 builder.Services.AddProblemDetails();
 builder.Services.AddApiVersioning(options =>
@@ -22,7 +26,29 @@ builder.Services.AddApiVersioning(options =>
 }).AddMvc().AddApiExplorer();
 builder.Services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.AddSecurityDefinition("ApiKey", new OpenApiSecurityScheme
+    {
+        Description = "X-API-KEY must appear in header",
+        Type = SecuritySchemeType.ApiKey,
+        Name = "X-API-KEY",
+        In = ParameterLocation.Header,
+        Scheme = "ApiKeyScheme"
+    });
+
+    var key = new OpenApiSecurityScheme()
+    {
+        Reference = new OpenApiReference
+        {
+            Type = ReferenceType.SecurityScheme,
+            Id = "ApiKey"
+        },
+        In = ParameterLocation.Header
+    };
+    var requirement = new OpenApiSecurityRequirement { { key, new List<string>() } };
+    options.AddSecurityRequirement(requirement);
+});
 
 var app = builder.Build();
 if (app.Environment.IsDevelopment())
@@ -33,7 +59,7 @@ if (app.Environment.IsDevelopment())
         var descriptions = app.DescribeApiVersions();
         foreach (var description in descriptions)
         {
-            options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", 
+            options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json",
                 description.GroupName.ToUpperInvariant());
         }
     });

--- a/Src/WeatherForecast.Api/appsettings.json
+++ b/Src/WeatherForecast.Api/appsettings.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApiKey": "1234567890"
 }


### PR DESCRIPTION
This commit introduces a custom API key authentication mechanism to enhance security and requires authorization for accessing the WeatherForecastController. The key changes include:

- The addition of the `[Authorize]` attribute to `WeatherForecastController`, making authentication mandatory for all its actions.
- Implementation of API key authentication by configuring a new authentication scheme named "ApiKey" in `Program.cs`, along with the creation of `ApiKeyAuthenticationSchemeOptions` and `ApiKeyAuthenticationSchemeHandler` for handling the authentication logic.
- Update of the Swagger configuration in `Program.cs` to include the API key authentication as a security definition, enabling the Swagger UI to prompt for an API key for testing endpoints.
- Inclusion of the API key in `appsettings.json`, which is required by clients to authenticate via the "X-Api-Key" header.
- Miscellaneous updates to ensure compatibility with the new authentication setup, including the necessary namespace addition in `WeatherForecastController` and adjustments to the Swagger UI setup in `Program.cs`.

These changes collectively improve the application's security posture by introducing API key authentication and ensuring that access to critical endpoints is properly controlled.